### PR TITLE
update raft_test TestLeaderElection2AA

### DIFF
--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -83,7 +83,7 @@ func TestLeaderElection2AA(t *testing.T) {
 		// are returned instead of the votes being ignored.
 		{newNetworkWithConfig(cfg,
 			nil, entsWithConfig(cfg, 1), entsWithConfig(cfg, 1), entsWithConfig(cfg, 1, 1), nil),
-			StateFollower, 1},
+			StateCandidate, 1},
 	}
 
 	for i, tt := range tests {


### PR DESCRIPTION
change expected state to StateCandidate. since implementation of prevote is not required